### PR TITLE
Make stale workflow "usable" out of the box

### DIFF
--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -1,8 +1,7 @@
-name: Comment on Stale Issues
-
+name: 'Close stale issues and pull requests with no recent activity'
 on:
-    schedule:
-      - cron: '30 1 * * *'
+  schedule:
+  - cron: "30 1 * * *"
 
 permissions:
   issues: write
@@ -12,10 +11,14 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
-        with:
-            days-before-close: -1
-            days-before-issue-stale: 30
-            days-before-pr-stale: 30
-            stale-pr-message: "This PR is stale. Add a nice message, can mention maintainers or maintainer team to draw attention"
-            stale-issue-message: "This issue is stale. Add a nice message, can mention maintainers or maintainer team to draw attention"
+    - uses: actions/stale@v9
+      with:
+        stale-issue-message: 'This issue has been marked as stale due to 60 days of inactivity. To prevent automatic closure in 10 days, remove the stale label or add a comment. You can reopen a closed issue at any time.'
+        stale-pr-message: 'This pull request has been marked as stale due to 60 days of inactivity. To prevent automatic closure in 10 days, remove the stale label or add a comment. You can reopen a closed pull request at any time.'
+        exempt-issue-labels: bug,enhancement
+        exempt-pr-labels: bug,enhancement
+        days-before-stale: 60
+        days-before-close: 10
+        remove-stale-when-updated: true
+        remove-issue-stale-when-updated: true
+        remove-pr-stale-when-updated: true


### PR DESCRIPTION
I noticed many not updating the default stale messages. We either should update it like so or disable the schedule. 

I took how meta-qcom is using it and doubled the number of days. Thoughts @craigez ?