### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/qualcomm-organization-repolinter.yml
+++ b/.github/workflows/qualcomm-organization-repolinter.yml
@@ -1,6 +1,8 @@
 name: Qualcomm Organization Repolinter
 
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
   repolinter:


### PR DESCRIPTION
Potential fix for [https://github.com/qualcomm/qualcomm-repository-template/security/code-scanning/1](https://github.com/qualcomm/qualcomm-repository-template/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions`. Based on the workflow's functionality, it only needs read access to the repository contents. Therefore, the `permissions` block should specify `contents: read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
