### PR TITLE
ci: add "workflow_call" event to qcom repolinter

### DIFF
--- a/.github/workflows/qualcomm-organization-repolinter.yml
+++ b/.github/workflows/qualcomm-organization-repolinter.yml
@@ -1,6 +1,6 @@
 name: Qualcomm Organization Repolinter
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_call]
 permissions:
   contents: read
 


### PR DESCRIPTION
Make qualcomm-organization-repolinter.yml callable to avoid duplication.