### PR TITLE
Update GitHub workflow to use QC Preflight Checks v2.0.0

### DIFF
--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -1,24 +1,22 @@
-name: Qualcomm Preflight Checks
+name: QC Preflight Checks
+
 on:
-  pull_request_target:
-    branches: [ main ]
+  pull_request:
   push:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
-permissions:
- contents: read
- security-events: write
-
 jobs:
-  qcom-preflight-checks:
-    uses: qualcomm/qcom-reusable-workflows/.github/workflows/qcom-preflight-checks-reusable-workflow.yml@v1.1.4
+  preflight:
+    name: Run QC Preflight Checks
+    uses: qualcomm/qcom-reusable-workflows/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml@v2.0.0
     with:
-        # ✅ Preflight Checkers
-        repolinter: true                   # default: true
-        semgrep: true                      # default: true
-        copyright-license-detector: true   # default: true
-        pr-check-emails: true              # default: true
-        dependency-review: true            # default: true
-    secrets:
-      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+      enable-semgrep-scan: true
+      enable-dependency-review: true
+      enable-repolinter-check: true
+      enable-copyright-license-check: true
+      enable-commit-email-check: true
+      enable-commit-msg-check: false
+    permissions:
+      contents: read
+      security-events: write


### PR DESCRIPTION
## Summary

- Rename workflow from "Qualcomm Preflight Checks" to "QC Preflight Checks"
- Change trigger from pull_request_target to pull_request
- Update reusable workflow reference from v1.1.4 to v2.0.0
- Update parameter naming convention to use enable-* prefix
- Add enable-commit-msg-check parameter (set to false)
- Move permissions section inside the job definition