### PR TITLE
chore: update reusable workflow reference from v2.0.0 to v2

### DIFF
--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   preflight:
     name: Run QC Preflight Checks
-    uses: qualcomm/qcom-reusable-workflows/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml@v2.0.0
+    uses: qualcomm/qcom-reusable-workflows/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml@v2
     with:
       enable-semgrep-scan: true
       enable-dependency-review: true


### PR DESCRIPTION
## Summary

Use major version tag (v2) instead of specific version (v2.0.0) to automatically receive minor and patch updates while maintaining compatibility with the v2 major version.