### PR TITLE
ci: added option for armor-checker

### DIFF
--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -17,6 +17,8 @@ jobs:
       enable-copyright-license-check: true
       enable-commit-email-check: true
       enable-commit-msg-check: false
+      enable-armor-checkers: false
+
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
## Summary

Added option for enable-armor-checker to explicitly enable or disable during CI run this ensures source code follows API and ABI backward compatibility