### PR TITLE
docs: require explicit license selection in template

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,26 +1,13 @@
-Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+REPLACE-ME: This template does NOT provide a default license.
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-* Redistributions of source code must retain the above copyright
-  notice, this list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above
-  copyright notice, this list of conditions and the following
-  disclaimer in the documentation and/or other materials provided
-  with the distribution.
-* Neither the name of the copyright holder nor the names of its
-  contributors may be used to endorse or promote products derived
-  from this software without specific prior written permission.
+Before publishing this repository, you MUST replace the entire contents of
+this file with the full text of your project's approved license.
 
-THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
-WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
-ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
-BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
-BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
-OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
-IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+1. Confirm the correct license for your project per your organization's
+   license approval guidelines.
+2. Replace all of the text in this file with the full, unmodified text of
+   that approved license.
+3. Update the "License" section in README.md to name the chosen license and
+   link to it here.
+
+Do not publish this repository until this file contains an approved license.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 **After repository creation:**
 - [ ] Update this `README.md`. Update the Project Name, description, and all sections. Remove this checklist.
-- [ ] If required, update `LICENSE.txt` and the License section with your project's approved license
+- [ ] **Specify your license.** This template does NOT ship with a default license. Identify your project's approved license per your organization's license approval guidelines.
+- [ ] **Create `LICENSE.txt`.** Replace the placeholder text in `LICENSE.txt` with the full text of your project's approved license.
+- [ ] **Update the License section** below to name your approved license and link to it.
 - [ ] Search this repo for "REPLACE-ME" and update all instances accordingly
 - [ ] Update `CONTRIBUTING.md` as needed
 - [ ] Review the workflows in `.github/workflows`, updating as needed. See https://docs.github.com/en/actions for information on what these files do and how they work.
 - [ ] Review and update the suggested Issue and PR templates as needed in `.github/ISSUE_TEMPLATE` and `.github/PULL_REQUEST_TEMPLATE`
+- [ ] Remove this checklist
 
 # Project Name
 
@@ -44,4 +47,4 @@ How to contact maintainers. E.g. GitHub Issues, GitHub Discussions could be indi
 
 *\<update with your project name and license\>*
 
-*\<REPLACE-ME\>* is licensed under the [BSD-3-clause License](https://spdx.org/licenses/BSD-3-Clause.html). See [LICENSE.txt](LICENSE.txt) for the full license text.
+*\<REPLACE-ME\>* is licensed under the *\<REPLACE-ME: license name and SPDX link\>*. See [LICENSE.txt](LICENSE.txt) for the full license text.

--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ How to contact maintainers. E.g. GitHub Issues, GitHub Discussions could be indi
 
 *\<update with your project name and license\>*
 
-*\<REPLACE-ME\>* is licensed under the *\<REPLACE-ME: license name and SPDX link (locate your license at https://spdx.org/licenses/) \>*. See [LICENSE.txt](LICENSE.txt) for the full license text.
+*\<REPLACE-ME\>* is licensed under the [REPLACE-ME with license name](https://spdx.org/licenses/REPLACE-ME-with-correct-URL-to-SPDX-license). See [LICENSE.txt](LICENSE.txt) for the full license text.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 **After repository creation:**
 - [ ] Update this `README.md`. Update the Project Name, description, and all sections. Remove this checklist.
-- [ ] **Specify your license.** This template does NOT ship with a default license. Identify your project's approved license per your organization's license approval guidelines.
+- [ ] **Specify your license.** This template does NOT ship with a default license. Identify your project's approved license per your organization's license approval guidelines. 
 - [ ] **Create `LICENSE.txt`.** Replace the placeholder text in `LICENSE.txt` with the full text of your project's approved license.
 - [ ] **Update the License section** below to name your approved license and link to it.
 - [ ] Search this repo for "REPLACE-ME" and update all instances accordingly
@@ -47,4 +47,4 @@ How to contact maintainers. E.g. GitHub Issues, GitHub Discussions could be indi
 
 *\<update with your project name and license\>*
 
-*\<REPLACE-ME\>* is licensed under the *\<REPLACE-ME: license name and SPDX link\>*. See [LICENSE.txt](LICENSE.txt) for the full license text.
+*\<REPLACE-ME\>* is licensed under the *\<REPLACE-ME: license name and SPDX link (locate your license at https://spdx.org/licenses/) \>*. See [LICENSE.txt](LICENSE.txt) for the full license text.


### PR DESCRIPTION
Remove the default BSD-3-Clause license text from LICENSE.txt and replace it with placeholder instructions, so users must supply their project's approved license before publishing. Update the README 'After repository creation' checklist and License section to make specifying the approved license a required step rather than an optional one.
