### PR TITLE
Update Stale workflows to align with QLI

### DIFF
--- a/.github/workflows/Readme.md
+++ b/.github/workflows/Readme.md
@@ -3,4 +3,4 @@ This folder contains workflows that are helpful for maintaining a smooth and sec
 
 Workflows:
 1. `qcom-preflight-checks.yml` - This workflow runs several preflight checks, including copyight, email, repolinter, and security checks.  See [qualcomm/qcom-actions](https://github.com/qualcomm/qcom-actions)
-2. `stale-issues.yaml` - This workflow will periodically run every 30 days to check for stalled issues and PRs. If the workflow detects any stalled issues and/or PRs, it will automatically leave just a comment to draw attention.
+2. `stale-issues.yaml` - This workflow will run daily and mark inactive Issues and PRs as stale with a comment and a label. It's currently configured to mark PRs and Issues as stale after 30 days. PRs are then auto-closed after an additional 5 days of inactivity. Adjust this workflow as needed.

--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -11,7 +11,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v9
+    - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899
       with:
         stale-issue-message: 'This issue has been marked as stale due to 30 days of inactivity. Please add a comment and close if it is resolved or if it is no longer relevant.'
         stale-pr-message: 'This pull request has been marked as stale due to 30 days of inactivity. To prevent automatic closure in 5 days, remove the stale label or add a comment. You can reopen a closed pull request at any time.'

--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -1,4 +1,4 @@
-name: 'Close stale issues and pull requests with no recent activity'
+name: 'Mark or close stale issues and pull requests with no recent activity'
 on:
   schedule:
   - cron: "30 1 * * *"
@@ -11,12 +11,15 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v10
+    - uses: actions/stale@v9
       with:
-        stale-issue-message: 'Remove the stale label or add a comment to reset the inactivity timer.'
-        stale-pr-message: 'Remove the stale label or add a comment to reset the inactivity timer'
+        stale-issue-message: 'This issue has been marked as stale due to 30 days of inactivity. Please add a comment and close if it is resolved or if it is no longer relevant.'
+        stale-pr-message: 'This pull request has been marked as stale due to 30 days of inactivity. To prevent automatic closure in 5 days, remove the stale label or add a comment. You can reopen a closed pull request at any time.'
+        exempt-issue-labels: bug,enhancement
+        exempt-pr-labels: bug,enhancement
         days-before-stale: 30
-        days-before-close: -1
+        days-before-close: 5
+        days-before-issue-close: -1
         remove-stale-when-updated: true
         remove-issue-stale-when-updated: true
         remove-pr-stale-when-updated: true


### PR DESCRIPTION
Align with PdM ask for QLI: mark PRs stale after 30 days and then close them after another 5 days of inactivity. Issues are not closed.